### PR TITLE
Make compatible with serverless-aws-resource-names

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,10 +47,10 @@ class ServerlessPlugin {
   }
 
   addTags() {
-    const stackName = `${this.serverless.service.service}-${this.options.stage}`;
+    const awsService = this.serverless.getProvider('aws');
+    const stackName = awsService.naming.getStackName();
     const params = { StackName: stackName };
 
-    const awsService = this.serverless.getProvider('aws');
     // const credentials = awsService.getCredentials();
 
     if (this.serverless.service.plugins.includes('serverless-plugin-split-stacks')) {


### PR DESCRIPTION
We utilize the serverless-aws-resource-names plugin to have sls follow our existing naming conventions. I just tried to use api-gateway-stage-tag-plugin, and it works great except it is not compatible with serverless-aws-resource-names. Could you review this PR, and if it looks ok, merge into your mainline and release?