### PR TITLE
Fixed TypeError issue when using serverless-plugin-split-stacks in a mode other than perType

### DIFF
--- a/index.js
+++ b/index.js
@@ -55,7 +55,10 @@ class ServerlessPlugin {
     const stackName = awsService.naming.getStackName();
     const params = { StackName: stackName };
 
-    if (this.serverless.service.plugins.includes('serverless-plugin-split-stacks')) {
+    if (this.serverless.service.plugins.includes('serverless-plugin-split-stacks')
+        && this.serverless.service.custom.splitStacks
+        && this.serverless.service.custom.splitStacks.perType === true
+    ) {
       this.cfnService.describeStackResources(params, (substackErr, substackData) => {
         if (substackErr) {
           this.serverless.cli.log('[ERROR]: Could not describe stack resources.');


### PR DESCRIPTION
While using `api-gateway-stage-tag-plugin` along with `serverless-plugin-split-stacks` in a mode other than `perType`, the Following `TypeError` occurs during the tagging phase:

Type Error ---------------------------------------------
 
  TypeError: Cannot read property PhysicalResourceId of undefined
      at Response.<anonymous> (.../node_modules/api-gateway-stage-tag-plugin/index.js:67:31)
      at Request.<anonymous>

This is happening because the feature introduced in [v1.0.3](https://github.com/mikepatrick/api-gateway-stage-tag-plugin/releases/tag/v1.0.3) only addresses the `serverless-plugin-split-stacks`'s `perType` option. Since the `serverless-plugin-split-stacks` `perFunction` and `perGroupFunction` API resources still reside in the root stack, they should not follow the same logic, instead the root stack should be the one used for tagging and that's what it's being fixed here.