### PR TITLE
Explicitly set region when creating AWS services

### DIFF
--- a/index.js
+++ b/index.js
@@ -6,8 +6,12 @@ class ServerlessPlugin {
     this.options = options;
 
     const awsService = this.serverless.getProvider('aws');
-    this.cfnService = new awsService.sdk.CloudFormation(awsService.getCredentials());
-    this.apigwService = new awsService.sdk.APIGateway(awsService.getCredentials());
+    
+    const credentials = awsService.getCredentials();
+    credentials.region = this.serverless.providers.aws.getRegion();
+    
+    this.cfnService = new awsService.sdk.CloudFormation(credentials);
+    this.apigwService = new awsService.sdk.APIGateway(credentials);
 
     this.hooks = {
       'after:deploy:deploy': this.addTags.bind(this),


### PR DESCRIPTION
I'm getting this error when trying to use the plugin:

> Serverless: ConfigError: Missing region in config

I've basically just pulled the fix from https://github.com/amplify-education/serverless-domain-manager/pull/307